### PR TITLE
Added controllerInitiator which can be used to change the instantiate process of a Controller class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <buildVersion>1.0.1-SNAPSHOT</buildVersion>
+        <buildVersion>1.0.2-SNAPSHOT</buildVersion>
     </properties>
 
     <groupId>org.javawebstack</groupId>


### PR DESCRIPTION
An example use-case would be to easily use a DI framework like Dagger2, Guice for controller instantiation.
New feature has been tested with the todo-app-example project.
Version bumped to 1.0.2-SNAPSHOT.