### PR TITLE
Form method override support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,18 @@
         <url>https://github.com/JavaWebStack/http-server/tree/master</url>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.javawebstack</groupId>
             <artifactId>validator</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/src/main/java/org/javawebstack/httpserver/Exchange.java
+++ b/src/main/java/org/javawebstack/httpserver/Exchange.java
@@ -290,7 +290,7 @@ public class Exchange {
     private HTTPMethod getRequestMethodFromSocket(IHTTPSocket socket) {
         if ("websocket".equalsIgnoreCase(socket.getRequestHeader("upgrade")))
             return HTTPMethod.WEBSOCKET;
-        if ((socket.getRequestMethod() == HTTPMethod.GET || socket.getRequestMethod() == HTTPMethod.POST) && getMimeType() == MimeType.X_WWW_FORM_URLENCODED) {
+        if (server.isFormMethods() && (socket.getRequestMethod() == HTTPMethod.GET || socket.getRequestMethod() == HTTPMethod.POST) && getMimeType() == MimeType.X_WWW_FORM_URLENCODED) {
             String rawMethodOverride = getBodyPathElement("_method").string();
             if (rawMethodOverride != null)
                 return HTTPMethod.valueOf(rawMethodOverride);

--- a/src/main/java/org/javawebstack/httpserver/Exchange.java
+++ b/src/main/java/org/javawebstack/httpserver/Exchange.java
@@ -288,7 +288,7 @@ public class Exchange {
     }
 
     private HTTPMethod getRequestMethodFromSocket(IHTTPSocket socket) {
-        if (socket.getRequestHeader("upgrade").equalsIgnoreCase("websocket"))
+        if ("websocket".equalsIgnoreCase(socket.getRequestHeader("upgrade")))
             return HTTPMethod.WEBSOCKET;
         if ((socket.getRequestMethod() == HTTPMethod.GET || socket.getRequestMethod() == HTTPMethod.POST) && getMimeType() == MimeType.X_WWW_FORM_URLENCODED) {
             String rawMethodOverride = getBodyPathElement("_method").string();

--- a/src/main/java/org/javawebstack/httpserver/HTTPServer.java
+++ b/src/main/java/org/javawebstack/httpserver/HTTPServer.java
@@ -43,6 +43,7 @@ public class HTTPServer implements RouteParamTransformerProvider {
     private final Map<String, RequestHandler> beforeMiddleware = new HashMap<>();
     private final Map<String, AfterRequestHandler> afterMiddleware = new HashMap<>();
     private Function<Class<?>, Object> controllerInitiator = this::defaultControllerInitiator;
+    private boolean formMethods = true;
 
     public HTTPServer() {
         this(new UndertowHTTPSocketServer());
@@ -415,4 +416,12 @@ public class HTTPServer implements RouteParamTransformerProvider {
         return exceptionHandler;
     }
 
+    public boolean isFormMethods() {
+        return formMethods;
+    }
+
+    public HTTPServer disableFormMethods() {
+        formMethods = false;
+        return this;
+    }
 }


### PR DESCRIPTION
Adds the ability to override the request method using `_method` in forms.
The option can be disabled with `HTTPServer.disableFormMethods()`